### PR TITLE
Permit 200 responses from tracing gateway

### DIFF
--- a/src/oc_reporter_zipkin.erl
+++ b/src/oc_reporter_zipkin.erl
@@ -49,6 +49,8 @@ report(Spans, {Address, LocalEndpoint}) ->
             case httpc:request(post, {Address, [], "application/json", JSON}, [], []) of
                 {ok, {{_, 202, _}, _, _}} ->
                     ok;
+                {ok, {{_, 200, _}, _, _}} ->
+                    ok;
                 {ok, {{_, Code, _}, _, Message}} ->
                     ?LOG_ERROR("Zipkin: Unable to send spans, Zipkin reported an error: ~p : ~p",
                               [Code, Message]);


### PR DESCRIPTION
I'm adding tracing to a phoenix app which reports to a SignalFX smart gateway, and I'm seeing our logs are flooded with

```
[error] Zipkin: Unable to send spans, Zipkin reported an error: 200 : '"OK"'
```

If I'm understanding this library correctly, this proposal should permit the `200 "OK"` response headers + bodies we're getting back from the tracing gateway.